### PR TITLE
[fix] MemberRepository.findMemberByUserIdAndPw

### DIFF
--- a/src/main/java/TimeIsGold/TimeIsGold/domain/member/MemberRepository.java
+++ b/src/main/java/TimeIsGold/TimeIsGold/domain/member/MemberRepository.java
@@ -16,7 +16,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     
    
     @Query("select m from Member m left join fetch m.timetables t where m.userId = :id and m.pw = :pw")
-    Member findByUserIdAndPw(String userId, String pw);
+    Member findByUserIdAndPw(@Param("id") String userId, @Param("pw") String pw);
 
 
     Optional<Member> findMemberByUserIdAndPw(String userId, String pw);


### PR DESCRIPTION
메서드 파라미터에 @Param 어노테이션 적용